### PR TITLE
Add E-SCOUT page

### DIFF
--- a/_data/projects.yaml
+++ b/_data/projects.yaml
@@ -12,7 +12,8 @@
   subtitle: The Environmentally Sustainable Computing User Trial of the Green Algorithms Initiative
   group: current
   image: images/projects/carbon-icons.jpg
-  description: We are running an international multi-centre study to compare the effectiveness of different types of feedback from carbon tracking tools for reducing the environmental impact of computational research. This trial will involve different user groups, leveraging a new open source dashboard for high-performance computing (HPC) that we have built. To get involved, register interest [here](https://zcmp.eu/nvfL).
+  link: /projects/e-scout/
+  description: We are running an international multi-centre study to compare the effectiveness of different types of feedback from carbon tracking tools for reducing the environmental impact of computational research. This trial will involve different user groups, leveraging a new open source dashboard for high-performance computing (HPC) that we have built. To get involved, [register interest here](https://zcmp.eu/nvfL).
   tags:
     - research
 

--- a/projects/e-scout/index.md
+++ b/projects/e-scout/index.md
@@ -1,0 +1,25 @@
+---
+title: E-SCOUT
+description: The Environmentally Sustainable Computing User Trial of the Green Algorithms Initiative
+---
+
+# {% include icon.html icon="fa-solid fa-comment" %}E-SCOUT
+
+<p style="text-align: center; font-size: 1.25rem;">The Environmentally Sustainable Computing User Trial of the Green Algorithms Initiative</p>
+
+<div style="text-align: center; margin: 20px 0;">
+    <a href="https://zcmp.eu/nvfL" style="display: inline-block; background-color: #386641; color: white; padding: 12px 24px; text-decoration: none; border-radius: 4px; font-weight: bold; margin: 15px 0;">Register Interest</a>
+</div>
+
+{% include section.html %}
+
+Tools such as the [Green Algorithms online calculator](https://calculator.green-algorithms.org/) have proven useful for researchers, research software engineers (RSEs) and organisations to understand the environmental impacts of their work, but some important questions remain: To what extent does carbon tracking incentivise green computing practices? Or how can we make sure it does?
+
+## Study aims
+To empirically evaluate the effectiveness of carbon reporting tools in reducing the environmental impacts of scientific computing, we are currently (spring 2025) designing an international multi-centre study called E-SCOUT. As part of the study, we will compare the effectiveness of different types of feedback for different user groups, leveraging a new open source dashboard for high-performance computing (HPC) that we have built.
+
+## Working closely with our users
+Reflecting its user-centred approach, E-SCOUT will use co-design throughout all stages to ensure that the feedback interventions are tailored to the users’ needs, goals and constraints. We are also planning to set up a steering group that brings together people with diverse perspectives for reflection and decision-making.
+
+## How can I get involved?
+If you work for a research performing organisation (RPO), such as a university, that uses HPC, and would be interested in getting involved, [register your interest here](https://zcmp.eu/nvfL). We also welcome interest from individuals for our steering group.


### PR DESCRIPTION
Add a page (not on Navigation) within Projects, dedicated to E-SCOUT. Content copied and slightly modified from Green Algorithms website. I will delete it from there once this is merged.